### PR TITLE
feat: update closing coroutine Scope

### DIFF
--- a/.agents/skills/kotlin-coroutines-structured-concurrency/SKILL.md
+++ b/.agents/skills/kotlin-coroutines-structured-concurrency/SKILL.md
@@ -1,0 +1,445 @@
+---
+description: Use when writing or reviewing Kotlin code that stores CoroutineScope, launches from init/non-suspending APIs, calls runBlocking, or catches broad exceptions around suspend calls.
+metadata:
+    github-path: skills/kotlin-coroutines-structured-concurrency
+    github-pinned: bc69bba2c7fbe96ee78a554498a579b12b67c9b4
+    github-ref: bc69bba2c7fbe96ee78a554498a579b12b67c9b4
+    github-repo: https://github.com/chrisbanes/skills
+    github-tree-sha: 3045cddcb91e9c0bc2fe71676a7966444d558b55
+name: kotlin-coroutines-structured-concurrency
+---
+# Kotlin coroutines: structured concurrency
+
+## Core principle
+
+A well-structured coroutine is a self-contained unit of asynchronous work — single entry, single exit, scoped to a lifecycle known at the call site.
+
+**Scopes should usually be tied to the caller's lifecycle, not stored as a property on the callee.** A stored `CoroutineScope` is a strong review signal: the class must prove it owns cancellation, error reporting, restart behavior, and lifecycle. Most repositories, managers, use cases, and data sources cannot prove that, so they should expose `suspend` APIs instead.
+
+The fix is almost always the same: **make the API `suspend` and let the caller own the scope.**
+
+## When to use this skill
+
+You're writing or reviewing Kotlin code and you see any of these:
+
+- A class with `private val scope: CoroutineScope` (constructor param stored as a property)
+- An `init { scope.launch { ... } }` block
+- A non-suspending public function whose body is `scope.launch { ... }`
+- `runBlocking { ... }` in suspend-capable application code, or in tests where `runTest` should apply
+- `runCatching { suspendCall() }` or a `catch` on `Exception` / `Throwable` around a `suspend` call without rethrowing `CancellationException`
+- A `catch (e: CancellationException)` (or equivalent) around suspension that does not rethrow
+
+## The silent-cancellation bug
+
+The reason an unowned `CoroutineScope` property is so dangerous: **once a scope is cancelled, every future `launch` on it silently completes as cancelled — no exception, no log, nothing.** The work just doesn't happen. This is one of the hardest coroutine bugs to diagnose, and it appears when a class holds a long-lived reference to a lifecycle it does not own.
+
+If APIs are `suspend`, this can't happen: the caller's scope is either alive (work runs) or the call site cancels (the caller knows).
+
+## Anti-patterns and fixes
+
+### 1. CoroutineScope stored as a property
+
+```kotlin
+// ❌ BAD
+@Inject
+class UserRepository(
+    private val scope: CoroutineScope,
+    private val api: UserApi,
+) {
+    fun refresh() {
+        scope.launch { _state.value = api.fetchUser() }
+    }
+}
+
+// ✅ GOOD
+@Inject
+class UserRepository(
+    private val api: UserApi,
+) {
+    suspend fun refresh(): User = api.fetchUser()
+}
+```
+
+The repository no longer needs to know about coroutines at all. The caller (a ViewModel, a use case) decides on what scope, with what error handling, with what cancellation semantics.
+
+### 2. init-block launches
+
+```kotlin
+// ❌ BAD: construction-time side effect, unbounded work
+class UserSession(private val scope: CoroutineScope, private val api: Api) {
+    init { scope.launch { _user.value = api.load() } }
+}
+```
+
+The constructor returns immediately. The caller can't `await` the load, can't see errors, can't cancel. The class is "alive" but its state is undefined.
+
+```kotlin
+// ✅ GOOD: explicit bootstrap, caller owns the suspension
+class UserSession(private val api: Api) {
+    private var _user: User? = null
+    val user: User get() = checkNotNull(_user) { "Call init() first" }
+
+    suspend fun init() { _user = api.load() }
+}
+```
+
+### 3. Fire-and-forget from non-UI classes
+
+A non-suspending public function on a **non-UI class** (repository, manager, use case, data source) that launches into a class-owned scope. The caller gets no result, no error, no cancellation, and no guarantee the work ever ran.
+
+```kotlin
+// ❌ BAD — repository with stored scope and fire-and-forget public API
+class AnalyticsClient(private val scope: CoroutineScope, private val api: Api) {
+    fun track(event: Event) {
+        scope.launch { api.send(event) }      // caller has no idea what happens
+    }
+    fun signOut() {
+        scope.launch { api.signOut() }        // silent failure if scope cancelled
+    }
+}
+```
+
+```kotlin
+// ✅ GOOD
+class AnalyticsClient(private val api: Api) {
+    suspend fun track(event: Event) = api.send(event)
+    suspend fun signOut() = api.signOut()
+}
+```
+
+#### Carve-out: the UI ↔ state-holder boundary
+
+UI frameworks are non-suspending. A Composable's `onClick`, a Fragment's `onKeyEvent`, an Activity's `onNewIntent` — none can `suspend`. The state holder (ViewModel, Decompose Component, feature model, etc. — anything whose role is to absorb UI events and hold UI state) **is** the boundary that translates one-shot UI events into asynchronous work bound to the UI lifecycle. That's its job.
+
+```kotlin
+// ✅ GOOD — state holder absorbs a non-suspending UI event onto its scope
+class FavouritesViewModel(private val repo: FavouritesRepository) : ViewModel() {
+    fun onToggleFavourite(item: Item) {
+        viewModelScope.launch { repo.toggleFavourite(item) }
+    }
+}
+
+// in Compose:
+ListItem(onClick = { viewModel.onToggleFavourite(item) })
+```
+
+This is **not** the fire-and-forget anti-pattern. All three conditions must hold:
+
+1. **State holder for a UI surface** — a ViewModel, Decompose Component, feature model, or equivalent UI state holder. Not a repository, manager, use case, or data source.
+2. **Lifecycle-bound scope** — `viewModelScope`, a Component's `coroutineScope` that's cancelled on destroy, a Composable's `rememberCoroutineScope()`. Not `AppScope`, not an injected long-lived scope, not an ad-hoc `CoroutineScope(...)`.
+3. **Caller really is a UI event** — Composable callback, key handler, lifecycle hook. Not another business-logic class calling through the state holder.
+
+The repository / use case / data source layers underneath still expose `suspend` APIs. The state holder is the *only* layer where the non-suspending → suspending translation belongs.
+
+"It feels like a state holder" isn't enough. The question is "does the UI directly bind to this?" If no, the carve-out doesn't apply.
+
+### 4. Stored scopes that aren't injected
+
+The same anti-pattern, without an injected scope:
+
+```kotlin
+// ❌ BAD — same problem, scope is constructed in-class instead of injected
+class FooManager {
+    private val scope = MainScope()
+    private val scope = CoroutineScope(Dispatchers.Default + SupervisorJob())
+}
+```
+
+Lifecycle is now owned by nothing and lives forever. Replace with `suspend` APIs.
+
+The same is true if the instantiation is nested inside a function body — `fun foo() { CoroutineScope(...).launch { … } }` is just a stored scope with extra steps. Each call leaks a new uncancellable scope; bundling it into a `by lazy` property doesn't fix the underlying issue (the scope shouldn't exist at all).
+
+### 5. DI-bound singletons / initializers that launch
+
+A specific pattern that is hard to spot: a DI-bound class (`@SingleIn(AppScope)`, `@Singleton`, an `Initializer.initialize()`) launches a coroutine from its constructor / `init` block / `initialize()`. The launched work then has:
+
+- **A non-deterministic start time** — whenever the graph realizes the binding. Cold-start ordering is invisible.
+- **No observable lifecycle.** Nothing else in the codebase can see whether it's running or has crashed.
+- **No `stop()` / restart path.** If upstream enters a bad state, the loop is uncancellable.
+- **No calling code to grep for.** Readers can't find "who starts this and when".
+
+§1 says scopes should be tied to the caller's lifecycle. The DI-bound variant violates this indirectly: the *scope* may be injected, but the *launch* is hidden inside construction — same effect, harder to see.
+
+```kotlin
+// ❌ BAD — singleton boots work as a side effect of being constructed
+@SingleIn(AppScope::class)
+@Inject
+class TokenRefresher(
+    @ForScope(AppScope::class) private val scope: CoroutineScope,
+    private val auth: AuthService,
+) {
+    init {
+        scope.launch {
+            while (isActive) {
+                delay(5.minutes)
+                auth.refreshIfNeeded()
+            }
+        }
+    }
+}
+
+// ❌ ALSO BAD — Initializer.initialize() that *launches*, not just registers
+class TokenInvalidatorInitializer @Inject constructor(
+    @ForScope(AppScope::class) private val scope: CoroutineScope,
+    private val store: AuthStore,
+    private val invalidator: TokenInvalidator,
+) : Initializer {
+    override fun initialize() {
+        scope.launch { store.tokenChanges.collect { invalidator.invalidate() } }
+    }
+}
+```
+
+Both look like "application-scoped singletons", but the **When NOT to apply** carve-out is *not* permission to launch from `init` / `initialize()`. It's permission for a singleton to own a scope when its API is suspending.
+
+#### First ask: does this background-loop class need to exist at all?
+
+Most background-loop classes exist only because no one inverted the observation. Three answers, in order of preference:
+
+**Pattern 1 — invert into the consumer.** The class observes state forever to react when it changes. But *someone* mutates the state — sign-out flow, profile switch, flag-update handler. That mutation site is already in a coroutine context and is the natural place to do the work directly.
+
+```kotlin
+// ✅ GOOD — no background loop, no scope, no class. The mutation site does the work.
+class Authenticator(
+    private val authStore: AuthStore,
+    private val tokenInvalidator: TokenInvalidator,
+) {
+    suspend fun signOut() {
+        authStore.clearTokens()
+        tokenInvalidator.invalidate()   // direct call at the mutation site
+    }
+}
+```
+
+The background-loop class is **deleted**. The work happens where the state changes.
+
+When this applies: the consumer of the state has a clear lifecycle (a use case, an Authenticator, a service handler) and can perform the reaction inline.
+
+**Pattern 2 — scheduled work.** Genuinely periodic or deferred. Use WorkManager / BGTaskScheduler. The enqueue is one-shot; make it suspending and call it once from an orchestrator that already runs at startup.
+
+**Pattern 3 — explicit named launch site.** Sometimes the consumer is a synchronous API with no observable lifecycle (e.g., OpenTelemetry's `Sampler.shouldSample(...)`, an AIDL stub fanout, a broadcast receiver bridge). The observation has to live somewhere coroutine-aware, but it must live at an *explicit named call site* — not in the class's own `init`.
+
+```kotlin
+// ✅ GOOD — work is named; an explicit call site owns the launch
+@SingleIn(AppScope::class)
+class OtelConfigurableSampler(...) : Sampler {
+    @Volatile private var delegate: Sampler = ...
+
+    suspend fun observeRate(featureFlags: FeatureFlags) {
+        featureFlags.observe(OTEL_SAMPLING_RATE).collect { rate ->
+            delegate = Sampler.traceIdRatioBased(rate.coerceIn(0.0, 1.0))
+        }
+    }
+
+    override fun shouldSample(...) = delegate.shouldSample(...)
+}
+
+// wired explicitly at the OTel SDK init module:
+applicationScope.launch { otelSampler.observeRate(featureFlags) }
+```
+
+When this applies: the consumer is a synchronous API that calls *into* you with no observable lifecycle. The launch can't be invertible, but it must still be visible at a named call site.
+
+#### Test for which pattern fits
+
+"Is the consumer's lifecycle observable to me?"
+
+- **Yes, and they're already in a coroutine context** → Pattern 1. Push the subscription into them; delete the background-loop class.
+- **The work is periodic / deferred** → Pattern 2. Suspend enqueue called once.
+- **No, they're a synchronous API with no observable lifecycle** → Pattern 3. Explicit launch site, not `init`.
+
+If a fourth answer seems to fit — e.g., "I want a `Bootable` interface that launches everything for me" — that's the same anti-pattern with an extra layer of abstraction. The whole point is that launches be *visible*; auto-discovery by interface defeats it.
+
+#### Initializers are still fine — *if they only register*
+
+The `Initializer` pattern is correct when `initialize()` *registers* a listener or hook. The bug is when `initialize()` *launches* a coroutine.
+
+```kotlin
+// ✅ GOOD Initializer — registers a contributor, doesn't launch
+class FavouritesContributorInitializer @Inject constructor(
+    private val registry: ContributorRegistry,
+    private val favouritesContributor: FavouritesContributor,
+) : Initializer {
+    override fun initialize() {
+        registry.register(favouritesContributor)
+    }
+}
+```
+
+**`Initializer.initialize()` must not `launch` a coroutine.** If yours does, it's a Pattern 1/2/3 candidate.
+
+#### Diagnostic for review
+
+- Where is the start moment defined? If "wherever DI realizes me", bad.
+- Who can observe whether the work is running? If "no one", bad.
+- Who can stop or restart it? If "no one", bad.
+- Can a reader grep for the launch site? If no, bad.
+
+If the answers are "the consumer / the orchestrator / the named call site" — you're good.
+
+### 6. Swallowing `CancellationException`
+
+A `catch` clause around a `suspend` call that matches `CancellationException` — directly, or through `Exception` / `Throwable` — and doesn't rethrow usually turns cancellation into silent success. The parent coroutine thinks the child finished; the child keeps running (or its side effects do); the cancellation contract is broken.
+
+Same failure shape as §1's stored-scope bug, viewed from the other end: §1 hides the work *from* the caller's lifecycle; this hides cancellation *from* the work.
+
+```kotlin
+// ❌ BAD — catches CancellationException, never rethrows
+suspend fun fetch() {
+    try {
+        api.load()
+    } catch (e: Exception) {           // matches CancellationException too
+        logger.warn("load failed", e)
+    }
+}
+
+// ❌ ALSO BAD — runCatching has the same problem
+suspend fun fetch() {
+    runCatching { api.load() }
+        .onFailure { logger.warn("load failed", it) }
+}
+```
+
+The acceptable shapes:
+
+```kotlin
+// ✅ Separate catch first
+try { api.load() }
+catch (e: CancellationException) { throw e }
+catch (e: Exception) { logger.warn("load failed", e) }
+
+// ✅ Conditional rethrow inside the broad catch
+try { api.load() }
+catch (e: Exception) {
+    if (e is CancellationException) throw e
+    logger.warn("load failed", e)
+}
+
+// ✅ ensureActive() — good when the catch handles ordinary failures and you only need
+// to rethrow if the current coroutine is cancelled
+try { api.load() }
+catch (e: Exception) {
+    currentCoroutineContext().ensureActive()
+    logger.warn("load failed", e)
+}
+
+// ✅ runCatching with explicit guard
+runCatching { api.load() }
+    .onFailure {
+        if (it is CancellationException) throw it
+        logger.warn("load failed", it)
+    }
+
+// ✅ runCatching terminated with getOrThrow (cancellation flows back out)
+runCatching { api.load() }.getOrThrow()
+```
+
+The trigger is "a suspend call inside the `try`", not "the enclosing function is declared `suspend`". This applies inside any suspending body — `suspend fun`, a `launch { … }` lambda, a Flow `collect { … }`, etc.
+
+The common carve-out is an intentionally local timeout: catching `TimeoutCancellationException` from your own `withTimeout` and converting it to a domain result can be correct. Keep that catch narrow and close to the timeout. Do not use it as permission to swallow arbitrary cancellation.
+
+Catching a non-cancellation subtype (`IOException`, your own exception types) is fine — they don't extend `CancellationException`.
+
+### 7. `runBlocking`
+
+`runBlocking` parks the current thread until the lambda finishes. Inside suspend-capable or lifecycle-scoped application paths it is wrong: a thread that meant to be async is now blocked, structured concurrency is broken, and any cancellation upstream has no effect. It is the "callee makes a structural decision for the caller" anti-pattern at its most direct.
+
+```kotlin
+// ❌ BAD — bridging to suspend by blocking the calling thread
+fun saveUser(user: User) {
+    runBlocking { repository.save(user) }
+}
+```
+
+Three fixes, by context:
+
+**Suspend-capable application code** — make the function `suspend`:
+
+```kotlin
+// ✅ GOOD
+suspend fun saveUser(user: User) = repository.save(user)
+```
+
+If the immediate caller can't suspend either (a non-suspending UI callback, a `BroadcastReceiver` hook), use the existing lifecycle-bound scope at the boundary — see §3's UI ↔ state-holder carve-out. The fix is at the boundary, not inside `saveUser`.
+
+Legitimate blocking boundaries exist: `main` in a CLI tool, Java interop APIs that must return synchronously, framework callbacks with no suspending alternative, and migration shims. Keep `runBlocking` at that outer boundary, keep the body small, and call suspending code immediately.
+
+**Tests** — use `runTest`:
+
+```kotlin
+// ❌ BAD — real time, slow tests, no virtual delay
+@Test fun loadsUser() = runBlocking {
+    assertThat(repository.load().name).isEqualTo("Alice")
+}
+
+// ✅ GOOD
+@Test fun loadsUser() = runTest {
+    assertThat(repository.load().name).isEqualTo("Alice")
+}
+```
+
+`runTest` gives you virtual time (`delay()` returns immediately), `TestDispatcher` integration, and proper coroutine cleanup. Real-time `runBlocking` in tests makes them slow and flaky.
+
+**`ContentProvider` carve-out** — Android's `ContentProvider` methods (`query`, `insert`, `update`, `delete`, `onCreate`, `call`) are synchronous from outside the process. There is no way to suspend them. Inside *member functions* of a `ContentProvider` subclass (direct or indirect — not companion objects), `runBlocking` is the unavoidable bridge. Keep the body as short as possible and call into suspending code immediately:
+
+```kotlin
+// ✅ Acceptable in ContentProvider members only
+class MyProvider : ContentProvider() {
+    override fun query(...): Cursor? = runBlocking { dao.query(...) }
+}
+```
+
+This carve-out is for `android.content.ContentProvider` subclasses *only*. "It's like a `ContentProvider`" doesn't apply, and a `runBlocking` in a `ContentProvider`'s companion object is still a regular violation — the helper isn't part of the framework's synchronous surface.
+
+## Quick reference
+
+| Symptom | Anti-pattern | Fix |
+|---|---|---|
+| Class has `private val scope: CoroutineScope` | Stored scope on the callee | Remove. Make public APIs `suspend`. |
+| `init { scope.launch { ... } }` | Construction-time launch | Move to `suspend fun init()` / `login()` |
+| `fun foo() { scope.launch { ... } }` on a repository/manager/use case | Fire-and-forget from non-UI class | `suspend fun foo()`, let UI state holder pick the scope |
+| `fun onClick() { viewModelScope.launch { ... } }` on a state holder, called from UI | UI ↔ state-holder boundary — fine | Keep as-is (see §3 carve-out) |
+| `private val scope = MainScope()` | Internally-constructed stored scope | Same — remove, make APIs `suspend` |
+| `@SingleIn(AppScope) class X(scope) { init { scope.launch { … } } }` | DI-bound opaque launch (§5) | Expose `suspend fun run()`, launch from startup orchestrator |
+| `class Y : Initializer { override fun initialize() { scope.launch { … } } }` | Initializer that launches, not registers (§5) | Same — `suspend fun run()`, orchestrator owns lifecycle |
+| `try { suspendCall() } catch (e: Exception\|Throwable\|CancellationException) { … }` with no rethrow | Swallowed cancellation (§6) | Prefer `catch (e: CancellationException) { throw e }`; use `ensureActive()` only when that matches the intent |
+| `runCatching { suspendCall() }.onFailure { … }` with no cancellation guard | Same shape as above (§6) | Add `if (it is CancellationException) throw it`, or terminate with `.getOrThrow()` |
+| `runBlocking { … }` inside suspend-capable app code | Thread-blocking bridge (§7) | Make caller `suspend`; or use a lifecycle scope at the boundary |
+| `runBlocking { … }` in a test | Same — real-time bridging (§7) | Use `runTest { … }` |
+| `runBlocking { … }` inside a `ContentProvider.query`/`insert`/… member | Carve-out (§7) | Acceptable; keep the body minimal |
+
+## Refactoring guidance
+
+Removing an existing offender:
+
+1. **Start at the leaf.** Pick the class farthest from any UI — usually a repository or data source. Its public surface should be the easiest to convert.
+2. **Convert public functions to `suspend`** one at a time. The compiler will surface every caller.
+3. **At each caller, choose the scope deliberately:** `viewModelScope`, `lifecycleScope`, `coroutineScope { }`, or an explicit job. This is the choice that was missing before.
+4. **Delete the `CoroutineScope` constructor parameter** once nothing uses it. Remove the injection binding.
+
+Don't try to fix every class in one MR. Removing an anti-pattern is incremental work.
+
+## When NOT to apply
+
+- **UI state holders absorbing UI events.** A ViewModel/Component/feature model with `fun onClick(...) { viewModelScope.launch { ... } }` is correct — that's the boundary the framework needs. See §3 carve-out.
+- **Lifecycle owners with explicit cancellation and error policy.** Actors/services, app infrastructure, or application-scoped singletons may own a scope when they expose clear `close`/`cancel`/restart behavior or otherwise map directly to an application lifecycle. Inject `Application.applicationScope` explicitly rather than creating one ad-hoc. **This is not permission to launch from `init` / `initialize()`** — see §5.
+- **Already-suspending APIs** don't need any of this work.
+- **Tests** sometimes use `TestScope` as a deliberate ambient scope — that's a different pattern with explicit virtual-time control.
+
+## Red flags during review
+
+These thoughts mean the anti-pattern is back:
+
+| Thought | Reality |
+|---|---|
+| "I'll just add a `CoroutineExceptionHandler` to the scope" | The problem isn't error handling. The problem is the scope shouldn't exist. |
+| "I need to launch from `init` so the data's ready when consumers arrive" | Consumers reading state that isn't ready is the bug. Use phasing. |
+| "The caller doesn't want to deal with `suspend`" | Then the caller chooses fire-and-forget at their scope. Don't decide for them. |
+| "It's just a small fire-and-forget call" | Silent cancellation makes every fire-and-forget a potential silent failure. |
+| "We caught and logged the exception, so we're fine" | Did the catch rethrow `CancellationException`? If no, the coroutine is silently un-cancelled. (§6) |
+| "It's just one `runBlocking`, in a non-critical path" | Every `runBlocking` asserts the caller has no async option. If they do, it's the wrong primitive. (§7) |
+| "Tests are simpler with `runBlocking`" | They run in real time, can't fast-forward `delay`, and lose `TestDispatcher` semantics. Use `runTest`. (§7) |
+
+## Related
+
+- [`kotlin-flow-state-event-modeling`](../kotlin-flow-state-event-modeling/SKILL.md) — `StateFlow`, `SharedFlow`, `Channel`, `stateIn`, one-shot events, and related modeling.

--- a/.agents/skills/kotlin-flow-state-event-modeling/SKILL.md
+++ b/.agents/skills/kotlin-flow-state-event-modeling/SKILL.md
@@ -1,0 +1,188 @@
+---
+description: Use when writing or reviewing Kotlin Flow state and event APIs with StateFlow, MutableStateFlow.update, SharedFlow, Channel, stateIn, SharingStarted, .value, receiveAsFlow, one-shot events, or sentinel initial values.
+metadata:
+    github-path: skills/kotlin-flow-state-event-modeling
+    github-pinned: bc69bba2c7fbe96ee78a554498a579b12b67c9b4
+    github-ref: bc69bba2c7fbe96ee78a554498a579b12b67c9b4
+    github-repo: https://github.com/chrisbanes/skills
+    github-tree-sha: f849f7dc820c3be59f5bead0ad1ee241b27d1f28
+name: kotlin-flow-state-event-modeling
+---
+# Kotlin Flow: state and event modeling
+
+## Core principle
+
+**Pick the primitive that matches replay, fan-out, and synchronous-read requirements.** `StateFlow`, `SharedFlow`, `Channel`-backed flows, and cold `Flow` differ in buffering, who sees each emission, and whether `.value` exists. Wrong choices drop events, leak sharing coroutines, or force fake domain sentinels into state.
+
+## When to use this skill
+
+You're writing or reviewing Kotlin code involving:
+
+- `MutableStateFlow<T>(SomeSentinel)` — `NoUser`, `Empty`, `Loading`, etc. — because the real value is async
+- `.stateIn(...)` called inside a function rather than assigned to a property
+- `SharingStarted.WhileSubscribed(...)` on a flow whose `.value` is read synchronously and must stay fresh
+- `MutableSharedFlow` for navigation events, snackbars, or other one-shot emissions where loss would be a bug
+- `.map { }` on a `StateFlow` when consumers still need synchronous `.value`
+- `MutableStateFlow.value = _state.value.copy(...)` or update code that builds expensive objects inside `update { ... }`
+
+## SharedFlow for single-consumer fire-once events
+
+`SharedFlow` defaults have no replay buffer. If nothing is collecting at the exact instant of emission, the event is gone. For a **single UI consumer** handling exactly-once events such as navigation or snackbars, a buffered `Channel` exposed as a `Flow` often matches the semantics better:
+
+```kotlin
+// ❌ BAD
+private val _navEvents = MutableSharedFlow<NavigationEvent>()
+val navEvents: SharedFlow<NavigationEvent> = _navEvents.asSharedFlow()
+
+// ✅ GOOD
+private val _navEvents = Channel<NavigationEvent>(Channel.BUFFERED)
+val navEvents: Flow<NavigationEvent> = _navEvents.receiveAsFlow()
+```
+
+`Channel.receiveAsFlow()` is **fan-out, not broadcast**: with multiple collectors, each event is delivered to **one** collector. `Channel.BUFFERED` is bounded, so sends can suspend and `trySend` can fail. If multiple observers must all see the same event, use explicit state, durable storage, or a deliberately configured `SharedFlow` instead.
+
+## StateFlow polluted with invalid sentinel defaults
+
+`StateFlow` forces an initial value. When the real value is async, developers sometimes invent fake domain values — `NoUser`, `EmptyUser`, placeholder IDs — and every consumer is forced to treat that sentinel as real data.
+
+```kotlin
+// ❌ BAD — sentinel leaks into the type
+class UserSession(private val db: Db) {
+    private val _user = MutableStateFlow<User>(NoUser)
+    val user: StateFlow<User> = _user.asStateFlow()
+    init { scope.launch { _user.value = db.load() } }
+}
+```
+
+One fix is **phasing**: don't expose the `StateFlow` until the real value exists.
+
+```kotlin
+// ✅ GOOD — bootstrap suspends; observers only see real users
+class UserSession(private val db: Db) {
+    private var _user: MutableStateFlow<User>? = null
+    val user: StateFlow<User>
+        get() = checkNotNull(_user) { "Call login() first" }
+
+    suspend fun login() {
+        _user = MutableStateFlow(db.load())
+    }
+}
+```
+
+If absence, loading, or error is a real state, model it explicitly (`User?`, `sealed interface UserUiState`, `Result`, etc.). The bug is a fake domain value masquerading as real data, not every initial value.
+
+## Mutate MutableStateFlow with `update { ... }`
+
+Prefer `MutableStateFlow.update { current -> ... }` over reading `.value` and writing it back. `update` applies the transform atomically against the latest state, which avoids lost updates when multiple coroutines mutate the same state.
+
+```kotlin
+// BAD — read/modify/write can lose concurrent updates.
+_state.value = _state.value.copy(
+    selectedId = id,
+    details = details,
+)
+
+// GOOD — transform starts from the latest state.
+_state.update { current ->
+    current.copy(
+        selectedId = id,
+        details = details,
+    )
+}
+```
+
+Keep object creation outside the `update` block unless it needs the current state. The update lambda can be retried, so expensive work or side effects inside it may run more than once:
+
+```kotlin
+// GOOD — details does not depend on current state, so build it once.
+val details = Details.from(response)
+_state.update { current ->
+    current.copy(details = details)
+}
+
+// GOOD — derived value depends on current state, so compute it inside.
+_state.update { current ->
+    val nextItems = current.items.replaceById(updatedItem)
+    current.copy(items = nextItems)
+}
+```
+
+The block should be a pure, fast state transformation: no network calls, database writes, logging side effects, random IDs, or time reads unless those values were captured before the block.
+
+## `stateIn()` inside a function
+
+```kotlin
+// ❌ BAD — new sharing coroutine every call
+fun getPreferences(): StateFlow<Prefs> =
+    repo.prefsFlow.stateIn(scope, SharingStarted.Eagerly, Prefs.Default)
+```
+
+Every call to `getPreferences()` launches a fresh coroutine on `scope` that never completes. Performance dies fast under repeated reads.
+
+```kotlin
+// ✅ GOOD — one shared instance, computed once
+val preferences: StateFlow<Prefs> =
+    repo.prefsFlow.stateIn(viewModelScope, SharingStarted.Eagerly, Prefs.Default)
+```
+
+## `WhileSubscribed` with synchronous `.value`
+
+`SharingStarted.WhileSubscribed(timeout)` disconnects the upstream when there are no active collectors. While disconnected, `.value` returns the last cached value, which may be stale or still the initial value.
+
+**Rule:** if `.value` must be fresh or initialized without an active collector, use `SharingStarted.Eagerly` or explicit initialization. `WhileSubscribed` is fine when stale/cached values are acceptable and consumers primarily collect asynchronously.
+
+## `.map` on `StateFlow` loses `.value`
+
+```kotlin
+// ❌ BAD — `name.value` won't compile; it's now a plain Flow
+val name: Flow<String> = userState.map { it.name }
+```
+
+If you need synchronous `.value`, terminate the chain with `.stateIn(...)`:
+
+```kotlin
+// ✅ GOOD
+val name: StateFlow<String> = userState
+    .map { it.name }
+    .stateIn(viewModelScope, SharingStarted.Eagerly, userState.value.name)
+```
+
+Community “derived state flow” utilities run the transform on every `.value` read — only acceptable for fast, idempotent transforms. Default to `.stateIn(...)`.
+
+## Decision: which Flow type?
+
+| Need | Primitive |
+|------|-----------|
+| State that always has a value, read by both async collectors **and** synchronous code | `StateFlow`, often with `SharingStarted.Eagerly` when `.value` matters |
+| Hot stream, multiple subscribers, **no** requirement for synchronous `.value` | `SharedFlow` |
+| Discrete events for **one** consumer, exactly-once handoff | Consider `Channel(BUFFERED).receiveAsFlow()` |
+| Cold stream, one consumer per collection | Plain `Flow` |
+
+If you're tempted to reach for `SharedFlow`, ask: would dropping an emission be a bug, and how many consumers must see it? If one consumer must handle it exactly once, a `Channel` may fit. If every observer must see it, model durable state or configure a broadcast stream deliberately.
+
+## Quick reference
+
+| Symptom | Problem | Fix |
+|---------|---------|-----|
+| `MutableStateFlow<X>(FakeDomainValue)` | Invalid placeholder default | Model absence explicitly or use phase initialization |
+| `MutableSharedFlow<Event>` for single-consumer nav/snackbar | Lossy default event stream | Consider `Channel(BUFFERED).receiveAsFlow()` |
+| `fun foo() = flow.stateIn(...)` | Per-call sharing coroutine | Make it a `val` / shared instance |
+| `WhileSubscribed` + `.value` must be fresh/initialized | Stale or initial data | `SharingStarted.Eagerly` or explicit initialization |
+| `stateFlow.map { ... }` consumed as state | Lost `.value` | Terminate with `.stateIn(...)` |
+| `_state.value = _state.value.copy(...)` | Non-atomic read/modify/write | `_state.update { it.copy(...) }` |
+| Expensive object creation inside `update { ... }` that doesn't use current state | Work can repeat if update retries | Build before `update`; keep only current-state transforms inside |
+
+## Red flags during review
+
+| Thought | Reality |
+|---------|---------|
+| "We need `SharedFlow` because there are multiple subscribers" | Multiple subscribers change the semantics. `Channel.receiveAsFlow()` is not broadcast; choose the event model deliberately. |
+| "We'll use `WhileSubscribed` to save resources" | Only if stale/initial `.value` reads are acceptable. Verify before applying. |
+| "I'll use a sentinel until real data loads" | Consumers treat it as real domain; prefer explicit UI/state modeling or phasing. |
+| "I'll construct the new object inside `update` because it's convenient" | The lambda may retry. Construct outside unless it depends on the current state. |
+
+## Related
+
+- [`kotlin-coroutines-structured-concurrency`](../kotlin-coroutines-structured-concurrency/SKILL.md) — scope ownership, init launches, fire-and-forget boundaries, cancellation, `runBlocking`
+- [`compose-side-effects`](../compose-side-effects/SKILL.md) — collecting event flows and wiring side effects in Compose
+- [`compose-state-holder-ui-split`](../compose-state-holder-ui-split/SKILL.md) — where state holders expose flows to UI

--- a/README.md
+++ b/README.md
@@ -741,6 +741,10 @@ val protoDatastore = createProtoDatastore(
 )
 ```
 
+`createProtoDatastore` creates a DataStore scope owned by the returned `GenericProtoDatastore`.
+Call `protoDatastore.close()` when the datastore is no longer needed; if you pass `scope`, it is
+used as a parent lifecycle and is not cancelled by `close()`.
+
 Overloads accepting `okio.Path` and `kotlinx.io.files.Path` are also available:
 
 ```kotlin

--- a/README.md
+++ b/README.md
@@ -122,6 +122,10 @@ val datastore = createPreferencesDatastore(
 )
 ```
 
+`createPreferencesDatastore` creates a DataStore scope owned by the returned
+`GenericPreferencesDatastore`. Call `datastore.close()` when the datastore is no longer needed; if
+you pass `scope`, it is used as a parent lifecycle and is not cancelled by `close()`.
+
 Overloads accepting `okio.Path` and `kotlinx.io.files.Path` are also available:
 
 ```kotlin

--- a/generic-datastore/src/commonMain/kotlin/io/github/arthurkun/generic/datastore/core/DatastoreScope.kt
+++ b/generic-datastore/src/commonMain/kotlin/io/github/arthurkun/generic/datastore/core/DatastoreScope.kt
@@ -5,6 +5,7 @@ import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.IO
 import kotlinx.coroutines.Job
 import kotlinx.coroutines.SupervisorJob
+import kotlin.coroutines.EmptyCoroutineContext
 
 /**
  * Creates a [CoroutineScope] specifically for DataStore operations.
@@ -13,21 +14,19 @@ import kotlinx.coroutines.SupervisorJob
  * new [SupervisorJob] to the parent's [Job] to maintain structured concurrency.
  * If no parent is provided, a standalone scope is created.
  *
- * In both cases, the scope uses [Dispatchers.IO] to ensure disk I/O operations
- * are performed on the appropriate thread pool and a [SupervisorJob] to prevent
- * failures in individual tasks from canceling the entire scope.
+ * If the parent does not provide a dispatcher, the scope uses [Dispatchers.IO]
+ * to ensure disk I/O operations are performed on the appropriate thread pool.
+ * It also uses a [SupervisorJob] to prevent failures in individual tasks from
+ * canceling the entire scope.
  *
  * @param parentScope An optional [CoroutineScope] to link the new scope to.
- * @return A [CoroutineScope] configured with [Dispatchers.IO] and a [SupervisorJob].
+ * @return A [CoroutineScope] configured with fallback [Dispatchers.IO] and a [SupervisorJob].
  */
 internal fun createDatastoreScope(parentScope: CoroutineScope?): CoroutineScope {
-    if (parentScope == null) {
-        return CoroutineScope(Dispatchers.IO + SupervisorJob())
-    }
-
-    val parentJob = parentScope.coroutineContext[Job]
+    val parentContext = parentScope?.coroutineContext ?: EmptyCoroutineContext
+    val parentJob = parentContext[Job]
     return CoroutineScope(
-        parentScope.coroutineContext + Dispatchers.IO +
+        Dispatchers.IO + parentContext +
             SupervisorJob(parentJob),
     )
 }

--- a/generic-datastore/src/commonMain/kotlin/io/github/arthurkun/generic/datastore/core/DatastoreScope.kt
+++ b/generic-datastore/src/commonMain/kotlin/io/github/arthurkun/generic/datastore/core/DatastoreScope.kt
@@ -1,0 +1,34 @@
+package io.github.arthurkun.generic.datastore.core
+
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.IO
+import kotlinx.coroutines.Job
+import kotlinx.coroutines.SupervisorJob
+
+
+/**
+ * Creates a [CoroutineScope] specifically for DataStore operations.
+ *
+ * If a [parentScope] is provided, the new scope inherits its context and links a
+ * new [SupervisorJob] to the parent's [Job] to maintain structured concurrency.
+ * If no parent is provided, a standalone scope is created.
+ *
+ * In both cases, the scope uses [Dispatchers.IO] to ensure disk I/O operations
+ * are performed on the appropriate thread pool and a [SupervisorJob] to prevent
+ * failures in individual tasks from canceling the entire scope.
+ *
+ * @param parentScope An optional [CoroutineScope] to link the new scope to.
+ * @return A [CoroutineScope] configured with [Dispatchers.IO] and a [SupervisorJob].
+ */
+internal fun createDatastoreScope(parentScope: CoroutineScope?): CoroutineScope {
+    if (parentScope == null) {
+        return CoroutineScope(Dispatchers.IO + SupervisorJob())
+    }
+
+    val parentJob = parentScope.coroutineContext[Job]
+    return CoroutineScope(
+        parentScope.coroutineContext + Dispatchers.IO +
+            SupervisorJob(parentJob),
+    )
+}

--- a/generic-datastore/src/commonMain/kotlin/io/github/arthurkun/generic/datastore/core/DatastoreScope.kt
+++ b/generic-datastore/src/commonMain/kotlin/io/github/arthurkun/generic/datastore/core/DatastoreScope.kt
@@ -6,7 +6,6 @@ import kotlinx.coroutines.IO
 import kotlinx.coroutines.Job
 import kotlinx.coroutines.SupervisorJob
 
-
 /**
  * Creates a [CoroutineScope] specifically for DataStore operations.
  *

--- a/generic-datastore/src/commonMain/kotlin/io/github/arthurkun/generic/datastore/preferences/CreatePreferencesDatastore.kt
+++ b/generic-datastore/src/commonMain/kotlin/io/github/arthurkun/generic/datastore/preferences/CreatePreferencesDatastore.kt
@@ -10,11 +10,21 @@ import io.github.arthurkun.generic.datastore.core.PreferenceDefaults
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.IO
+import kotlinx.coroutines.Job
 import kotlinx.coroutines.SupervisorJob
 import kotlinx.serialization.json.Json
 import okio.Path.Companion.toPath
 import kotlin.jvm.JvmName
 import kotlinx.io.files.Path as KotlinxIoPath
+
+private fun preferencesDatastoreScope(parentScope: CoroutineScope?): CoroutineScope {
+    if (parentScope == null) {
+        return CoroutineScope(Dispatchers.IO + SupervisorJob())
+    }
+
+    val parentJob = parentScope.coroutineContext[Job]
+    return CoroutineScope(parentScope.coroutineContext + SupervisorJob(parentJob))
+}
 
 /**
  * Creates a [GenericPreferencesDatastore] from a path producer that returns a [String].
@@ -32,8 +42,9 @@ import kotlinx.io.files.Path as KotlinxIoPath
  *
  * @param corruptionHandler An optional [ReplaceFileCorruptionHandler] to handle data corruption.
  * @param migrations A list of [DataMigration] to apply when the DataStore is created.
- * @param scope The [CoroutineScope] to use for DataStore operations. The default creates an
- * unmanaged application-style scope; pass your own scope when you need explicit lifecycle control.
+ * @param scope Optional parent [CoroutineScope] for DataStore operations. The returned
+ * [GenericPreferencesDatastore] owns a child scope and cancels it from [GenericPreferencesDatastore.close].
+ * Pass a custom scope to tie the datastore to a parent lifecycle.
  * @param defaultJson The fallback [Json] instance for Kotlin-serialization-backed preferences.
  * @param producePath A lambda that returns the full file path as a [String].
  * @return A new [GenericPreferencesDatastore] instance.
@@ -41,19 +52,21 @@ import kotlinx.io.files.Path as KotlinxIoPath
 public fun createPreferencesDatastore(
     corruptionHandler: ReplaceFileCorruptionHandler<Preferences>? = null,
     migrations: List<DataMigration<Preferences>> = emptyList(),
-    scope: CoroutineScope = CoroutineScope(Dispatchers.IO + SupervisorJob()),
+    scope: CoroutineScope? = null,
     defaultJson: Json = PreferenceDefaults.defaultJson,
     producePath: () -> String,
 ): GenericPreferencesDatastore {
+    val datastoreScope = preferencesDatastoreScope(scope)
     val datastore = PreferenceDataStoreFactory.createWithPath(
         corruptionHandler = corruptionHandler,
         migrations = migrations,
-        scope = scope,
+        scope = datastoreScope,
         produceFile = { producePath().toPath() },
     )
     return GenericPreferencesDatastore(
         datastore = datastore,
         defaultJson = defaultJson,
+        ownedScope = datastoreScope,
     )
 }
 
@@ -65,8 +78,9 @@ public fun createPreferencesDatastore(
  *
  * @param corruptionHandler An optional [ReplaceFileCorruptionHandler] to handle data corruption.
  * @param migrations A list of [DataMigration] to apply when the DataStore is created.
- * @param scope The [CoroutineScope] to use for DataStore operations. The default creates an
- * unmanaged application-style scope; pass your own scope when you need explicit lifecycle control.
+ * @param scope Optional parent [CoroutineScope] for DataStore operations. The returned
+ * [GenericPreferencesDatastore] owns a child scope and cancels it from [GenericPreferencesDatastore.close].
+ * Pass a custom scope to tie the datastore to a parent lifecycle.
  * @param defaultJson The fallback [Json] instance for Kotlin-serialization-backed preferences.
  * @param produceOkioPath A lambda that returns the file path as an [okio.Path].
  * @return A new [GenericPreferencesDatastore] instance.
@@ -75,19 +89,21 @@ public fun createPreferencesDatastore(
 public fun createPreferencesDatastore(
     corruptionHandler: ReplaceFileCorruptionHandler<Preferences>? = null,
     migrations: List<DataMigration<Preferences>> = emptyList(),
-    scope: CoroutineScope = CoroutineScope(Dispatchers.IO + SupervisorJob()),
+    scope: CoroutineScope? = null,
     defaultJson: Json = PreferenceDefaults.defaultJson,
     produceOkioPath: () -> okio.Path,
 ): GenericPreferencesDatastore {
+    val datastoreScope = preferencesDatastoreScope(scope)
     val datastore = PreferenceDataStoreFactory.createWithPath(
         corruptionHandler = corruptionHandler,
         migrations = migrations,
-        scope = scope,
+        scope = datastoreScope,
         produceFile = produceOkioPath,
     )
     return GenericPreferencesDatastore(
         datastore = datastore,
         defaultJson = defaultJson,
+        ownedScope = datastoreScope,
     )
 }
 
@@ -99,8 +115,9 @@ public fun createPreferencesDatastore(
  *
  * @param corruptionHandler An optional [ReplaceFileCorruptionHandler] to handle data corruption.
  * @param migrations A list of [DataMigration] to apply when the DataStore is created.
- * @param scope The [CoroutineScope] to use for DataStore operations. The default creates an
- * unmanaged application-style scope; pass your own scope when you need explicit lifecycle control.
+ * @param scope Optional parent [CoroutineScope] for DataStore operations. The returned
+ * [GenericPreferencesDatastore] owns a child scope and cancels it from [GenericPreferencesDatastore.close].
+ * Pass a custom scope to tie the datastore to a parent lifecycle.
  * @param defaultJson The fallback [Json] instance for Kotlin-serialization-backed preferences.
  * @param produceKotlinxIoPath A lambda that returns the file path as a [KotlinxIoPath].
  * @return A new [GenericPreferencesDatastore] instance.
@@ -109,19 +126,21 @@ public fun createPreferencesDatastore(
 public fun createPreferencesDatastore(
     corruptionHandler: ReplaceFileCorruptionHandler<Preferences>? = null,
     migrations: List<DataMigration<Preferences>> = emptyList(),
-    scope: CoroutineScope = CoroutineScope(Dispatchers.IO + SupervisorJob()),
+    scope: CoroutineScope? = null,
     defaultJson: Json = PreferenceDefaults.defaultJson,
     produceKotlinxIoPath: () -> KotlinxIoPath,
 ): GenericPreferencesDatastore {
+    val datastoreScope = preferencesDatastoreScope(scope)
     val datastore = PreferenceDataStoreFactory.createWithPath(
         corruptionHandler = corruptionHandler,
         migrations = migrations,
-        scope = scope,
+        scope = datastoreScope,
         produceFile = { produceKotlinxIoPath().toString().toPath() },
     )
     return GenericPreferencesDatastore(
         datastore = datastore,
         defaultJson = defaultJson,
+        ownedScope = datastoreScope,
     )
 }
 
@@ -134,8 +153,9 @@ public fun createPreferencesDatastore(
  * @param fileName The name of the DataStore file, such as `settings.preferences_pb`.
  * @param corruptionHandler An optional [ReplaceFileCorruptionHandler] to handle data corruption.
  * @param migrations A list of [DataMigration] to apply when the DataStore is created.
- * @param scope The [CoroutineScope] to use for DataStore operations. The default creates an
- * unmanaged application-style scope; pass your own scope when you need explicit lifecycle control.
+ * @param scope Optional parent [CoroutineScope] for DataStore operations. The returned
+ * [GenericPreferencesDatastore] owns a child scope and cancels it from [GenericPreferencesDatastore.close].
+ * Pass a custom scope to tie the datastore to a parent lifecycle.
  * @param defaultJson The fallback [Json] instance for Kotlin-serialization-backed preferences.
  * @param producePath A lambda that returns the directory path as a [String].
  * @return A new [GenericPreferencesDatastore] instance.
@@ -144,18 +164,20 @@ public fun createPreferencesDatastore(
     fileName: String,
     corruptionHandler: ReplaceFileCorruptionHandler<Preferences>? = null,
     migrations: List<DataMigration<Preferences>> = emptyList(),
-    scope: CoroutineScope = CoroutineScope(Dispatchers.IO + SupervisorJob()),
+    scope: CoroutineScope? = null,
     defaultJson: Json = PreferenceDefaults.defaultJson,
     producePath: () -> String,
 ): GenericPreferencesDatastore {
+    val datastoreScope = preferencesDatastoreScope(scope)
     val datastore = PreferenceDataStoreFactory.createWithPath(
         corruptionHandler = corruptionHandler,
         migrations = migrations,
-        scope = scope,
+        scope = datastoreScope,
         produceFile = { producePath().toPath() / fileName },
     )
     return GenericPreferencesDatastore(
         datastore = datastore,
         defaultJson = defaultJson,
+        ownedScope = datastoreScope,
     )
 }

--- a/generic-datastore/src/commonMain/kotlin/io/github/arthurkun/generic/datastore/preferences/CreatePreferencesDatastore.kt
+++ b/generic-datastore/src/commonMain/kotlin/io/github/arthurkun/generic/datastore/preferences/CreatePreferencesDatastore.kt
@@ -7,24 +7,13 @@ import androidx.datastore.core.handlers.ReplaceFileCorruptionHandler
 import androidx.datastore.preferences.core.PreferenceDataStoreFactory
 import androidx.datastore.preferences.core.Preferences
 import io.github.arthurkun.generic.datastore.core.PreferenceDefaults
+import io.github.arthurkun.generic.datastore.core.createDatastoreScope
 import kotlinx.coroutines.CoroutineScope
-import kotlinx.coroutines.Dispatchers
-import kotlinx.coroutines.IO
-import kotlinx.coroutines.Job
-import kotlinx.coroutines.SupervisorJob
 import kotlinx.serialization.json.Json
 import okio.Path.Companion.toPath
 import kotlin.jvm.JvmName
 import kotlinx.io.files.Path as KotlinxIoPath
 
-private fun preferencesDatastoreScope(parentScope: CoroutineScope?): CoroutineScope {
-    if (parentScope == null) {
-        return CoroutineScope(Dispatchers.IO + SupervisorJob())
-    }
-
-    val parentJob = parentScope.coroutineContext[Job]
-    return CoroutineScope(parentScope.coroutineContext + SupervisorJob(parentJob))
-}
 
 /**
  * Creates a [GenericPreferencesDatastore] from a path producer that returns a [String].
@@ -56,7 +45,7 @@ public fun createPreferencesDatastore(
     defaultJson: Json = PreferenceDefaults.defaultJson,
     producePath: () -> String,
 ): GenericPreferencesDatastore {
-    val datastoreScope = preferencesDatastoreScope(scope)
+    val datastoreScope = createDatastoreScope(scope)
     val datastore = PreferenceDataStoreFactory.createWithPath(
         corruptionHandler = corruptionHandler,
         migrations = migrations,
@@ -93,7 +82,7 @@ public fun createPreferencesDatastore(
     defaultJson: Json = PreferenceDefaults.defaultJson,
     produceOkioPath: () -> okio.Path,
 ): GenericPreferencesDatastore {
-    val datastoreScope = preferencesDatastoreScope(scope)
+    val datastoreScope = createDatastoreScope(scope)
     val datastore = PreferenceDataStoreFactory.createWithPath(
         corruptionHandler = corruptionHandler,
         migrations = migrations,
@@ -130,7 +119,7 @@ public fun createPreferencesDatastore(
     defaultJson: Json = PreferenceDefaults.defaultJson,
     produceKotlinxIoPath: () -> KotlinxIoPath,
 ): GenericPreferencesDatastore {
-    val datastoreScope = preferencesDatastoreScope(scope)
+    val datastoreScope = createDatastoreScope(scope)
     val datastore = PreferenceDataStoreFactory.createWithPath(
         corruptionHandler = corruptionHandler,
         migrations = migrations,
@@ -168,7 +157,7 @@ public fun createPreferencesDatastore(
     defaultJson: Json = PreferenceDefaults.defaultJson,
     producePath: () -> String,
 ): GenericPreferencesDatastore {
-    val datastoreScope = preferencesDatastoreScope(scope)
+    val datastoreScope = createDatastoreScope(scope)
     val datastore = PreferenceDataStoreFactory.createWithPath(
         corruptionHandler = corruptionHandler,
         migrations = migrations,

--- a/generic-datastore/src/commonMain/kotlin/io/github/arthurkun/generic/datastore/preferences/CreatePreferencesDatastore.kt
+++ b/generic-datastore/src/commonMain/kotlin/io/github/arthurkun/generic/datastore/preferences/CreatePreferencesDatastore.kt
@@ -14,7 +14,6 @@ import okio.Path.Companion.toPath
 import kotlin.jvm.JvmName
 import kotlinx.io.files.Path as KotlinxIoPath
 
-
 /**
  * Creates a [GenericPreferencesDatastore] from a path producer that returns a [String].
  *

--- a/generic-datastore/src/commonMain/kotlin/io/github/arthurkun/generic/datastore/preferences/GenericPreferencesDatastore.kt
+++ b/generic-datastore/src/commonMain/kotlin/io/github/arthurkun/generic/datastore/preferences/GenericPreferencesDatastore.kt
@@ -46,6 +46,8 @@ import io.github.arthurkun.generic.datastore.preferences.optional.custom.Nullabl
 import io.github.arthurkun.generic.datastore.preferences.optional.custom.NullableObjectPrimitive
 import io.github.arthurkun.generic.datastore.preferences.optional.custom.NullableSerializedListPrimitive
 import io.github.arthurkun.generic.datastore.preferences.utils.dataOrEmpty
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.cancel
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.flow.map
@@ -65,14 +67,20 @@ import kotlinx.serialization.json.JsonElement
  *
  * @property datastore The underlying [DataStore<Preferences>] instance.
  * @property defaultJson The fallback [Json] instance for Kotlin-serialization-backed preferences.
+ * @property ownedScope The scope owned by this wrapper when it creates the underlying [DataStore].
  */
 public class GenericPreferencesDatastore(
     internal val datastore: DataStore<Preferences>,
     private val defaultJson: Json = PreferenceDefaults.defaultJson,
+    private val ownedScope: CoroutineScope? = null,
 ) : PreferencesDatastore {
 
     private val backupCreator = PreferenceBackupCreator(datastore)
     private val backupRestorer = PreferenceBackupRestorer(datastore)
+
+    override fun close() {
+        ownedScope?.cancel()
+    }
 
     /**
      * Creates a String preference.

--- a/generic-datastore/src/commonMain/kotlin/io/github/arthurkun/generic/datastore/preferences/PreferencesDatastore.kt
+++ b/generic-datastore/src/commonMain/kotlin/io/github/arthurkun/generic/datastore/preferences/PreferencesDatastore.kt
@@ -21,17 +21,7 @@ import kotlinx.serialization.json.JsonElement
  * The `nullable*` APIs model absence explicitly: when a key is not stored they return `null`,
  * and writing `null` removes the key.
  */
-public interface PreferencesDatastore {
-    /**
-     * Closes resources owned by this preferences datastore wrapper.
-     *
-     * Datastores created with `createPreferencesDatastore` own the DataStore scope and cancel it
-     * here. Wrappers around an externally-created `DataStore<Preferences>` may not own any
-     * resources, in which case this is a no-op.
-     */
-    public fun close() {
-    }
-
+public interface PreferencesDatastore : AutoCloseable {
     /**
      * Creates a String preference.
      *

--- a/generic-datastore/src/commonMain/kotlin/io/github/arthurkun/generic/datastore/preferences/PreferencesDatastore.kt
+++ b/generic-datastore/src/commonMain/kotlin/io/github/arthurkun/generic/datastore/preferences/PreferencesDatastore.kt
@@ -22,6 +22,8 @@ import kotlinx.serialization.json.JsonElement
  * and writing `null` removes the key.
  */
 public interface PreferencesDatastore : AutoCloseable {
+    override fun close() {}
+
     /**
      * Creates a String preference.
      *

--- a/generic-datastore/src/commonMain/kotlin/io/github/arthurkun/generic/datastore/preferences/PreferencesDatastore.kt
+++ b/generic-datastore/src/commonMain/kotlin/io/github/arthurkun/generic/datastore/preferences/PreferencesDatastore.kt
@@ -23,6 +23,16 @@ import kotlinx.serialization.json.JsonElement
  */
 public interface PreferencesDatastore {
     /**
+     * Closes resources owned by this preferences datastore wrapper.
+     *
+     * Datastores created with `createPreferencesDatastore` own the DataStore scope and cancel it
+     * here. Wrappers around an externally-created `DataStore<Preferences>` may not own any
+     * resources, in which case this is a no-op.
+     */
+    public fun close() {
+    }
+
+    /**
      * Creates a String preference.
      *
      * @param key The preference key.

--- a/generic-datastore/src/commonMain/kotlin/io/github/arthurkun/generic/datastore/proto/CreateProtoDatastore.kt
+++ b/generic-datastore/src/commonMain/kotlin/io/github/arthurkun/generic/datastore/proto/CreateProtoDatastore.kt
@@ -12,11 +12,21 @@ import io.github.arthurkun.generic.datastore.core.systemFileSystem
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.IO
+import kotlinx.coroutines.Job
 import kotlinx.coroutines.SupervisorJob
 import kotlinx.serialization.json.Json
 import okio.Path.Companion.toPath
 import kotlin.jvm.JvmName
 import kotlinx.io.files.Path as KotlinxIoPath
+
+private fun protoDatastoreScope(parentScope: CoroutineScope?): CoroutineScope {
+    if (parentScope == null) {
+        return CoroutineScope(Dispatchers.IO + SupervisorJob())
+    }
+
+    val parentJob = parentScope.coroutineContext[Job]
+    return CoroutineScope(parentScope.coroutineContext + SupervisorJob(parentJob))
+}
 
 /**
  * Creates a [GenericProtoDatastore] using an [OkioSerializer] and a path producer
@@ -31,15 +41,14 @@ import kotlinx.io.files.Path as KotlinxIoPath
  * @param key The key identifier for this proto datastore.
  * @param corruptionHandler An optional [ReplaceFileCorruptionHandler] to handle data corruption.
  * @param migrations A list of [DataMigration] to apply when the DataStore is created.
- * @param scope The [CoroutineScope] to use for DataStore operations. Defaults to an unmanaged
- *   `CoroutineScope(Dispatchers.IO + SupervisorJob())`, which is suitable for application-level
- *   singletons. To control the DataStore lifecycle (e.g., in a scoped component or for testing),
- *   pass a custom scope and cancel it when no longer needed:
+ * @param scope Optional parent [CoroutineScope] for DataStore operations. The returned
+ *   [GenericProtoDatastore] owns a child scope and cancels it from [GenericProtoDatastore.close].
+ *   Pass a custom scope to tie the datastore to a parent lifecycle:
  *   ```
  *   val scope = CoroutineScope(SupervisorJob() + Dispatchers.IO)
  *   val datastore = createProtoDatastore(scope = scope, ...) { "/path/to/file" }
  *   // When done:
- *   scope.cancel()
+ *   datastore.close()
  *   ```
  * @param defaultJson The default [Json] instance to use for Kotlin Serialization-based fields in this proto datastore.
  * @param producePath A lambda that returns the full file path as a [String].
@@ -51,10 +60,11 @@ public fun <T> createProtoDatastore(
     key: String = "proto_datastore",
     corruptionHandler: ReplaceFileCorruptionHandler<T>? = null,
     migrations: List<DataMigration<T>> = emptyList(),
-    scope: CoroutineScope = CoroutineScope(Dispatchers.IO + SupervisorJob()),
+    scope: CoroutineScope? = null,
     defaultJson: Json = PreferenceDefaults.defaultJson,
     producePath: () -> String,
 ): GenericProtoDatastore<T> {
+    val datastoreScope = protoDatastoreScope(scope)
     val datastore = DataStoreFactory.create(
         storage = OkioStorage(
             fileSystem = systemFileSystem,
@@ -63,13 +73,14 @@ public fun <T> createProtoDatastore(
         ),
         corruptionHandler = corruptionHandler,
         migrations = migrations,
-        scope = scope,
+        scope = datastoreScope,
     )
     return GenericProtoDatastore(
         datastore = datastore,
         defaultValue = defaultValue,
         key = key,
         defaultJson = defaultJson,
+        ownedScope = datastoreScope,
     )
 }
 
@@ -82,15 +93,14 @@ public fun <T> createProtoDatastore(
  * @param key The key identifier for this proto datastore.
  * @param corruptionHandler An optional [ReplaceFileCorruptionHandler] to handle data corruption.
  * @param migrations A list of [DataMigration] to apply when the DataStore is created.
- * @param scope The [CoroutineScope] to use for DataStore operations. Defaults to an unmanaged
- *   `CoroutineScope(Dispatchers.IO + SupervisorJob())`, which is suitable for application-level
- *   singletons. To control the DataStore lifecycle (e.g., in a scoped component or for testing),
- *   pass a custom scope and cancel it when no longer needed:
+ * @param scope Optional parent [CoroutineScope] for DataStore operations. The returned
+ *   [GenericProtoDatastore] owns a child scope and cancels it from [GenericProtoDatastore.close].
+ *   Pass a custom scope to tie the datastore to a parent lifecycle:
  *   ```
  *   val scope = CoroutineScope(SupervisorJob() + Dispatchers.IO)
  *   val datastore = createProtoDatastore(scope = scope, ...) { "/path/to/file" }
  *   // When done:
- *   scope.cancel()
+ *   datastore.close()
  *   ```
  * @param defaultJson The default [Json] instance to use for Kotlin Serialization-based fields in this proto datastore.
  * @param produceOkioPath A lambda that returns the file path as an [okio.Path].
@@ -103,10 +113,11 @@ public fun <T> createProtoDatastore(
     key: String = "proto_datastore",
     corruptionHandler: ReplaceFileCorruptionHandler<T>? = null,
     migrations: List<DataMigration<T>> = emptyList(),
-    scope: CoroutineScope = CoroutineScope(Dispatchers.IO + SupervisorJob()),
+    scope: CoroutineScope? = null,
     defaultJson: Json = PreferenceDefaults.defaultJson,
     produceOkioPath: () -> okio.Path,
 ): GenericProtoDatastore<T> {
+    val datastoreScope = protoDatastoreScope(scope)
     val datastore = DataStoreFactory.create(
         storage = OkioStorage(
             fileSystem = systemFileSystem,
@@ -115,13 +126,14 @@ public fun <T> createProtoDatastore(
         ),
         corruptionHandler = corruptionHandler,
         migrations = migrations,
-        scope = scope,
+        scope = datastoreScope,
     )
     return GenericProtoDatastore(
         datastore = datastore,
         defaultValue = defaultValue,
         key = key,
         defaultJson = defaultJson,
+        ownedScope = datastoreScope,
     )
 }
 
@@ -135,15 +147,14 @@ public fun <T> createProtoDatastore(
  * @param key The key identifier for this proto datastore.
  * @param corruptionHandler An optional [ReplaceFileCorruptionHandler] to handle data corruption.
  * @param migrations A list of [DataMigration] to apply when the DataStore is created.
- * @param scope The [CoroutineScope] to use for DataStore operations. Defaults to an unmanaged
- *   `CoroutineScope(Dispatchers.IO + SupervisorJob())`, which is suitable for application-level
- *   singletons. To control the DataStore lifecycle (e.g., in a scoped component or for testing),
- *   pass a custom scope and cancel it when no longer needed:
+ * @param scope Optional parent [CoroutineScope] for DataStore operations. The returned
+ *   [GenericProtoDatastore] owns a child scope and cancels it from [GenericProtoDatastore.close].
+ *   Pass a custom scope to tie the datastore to a parent lifecycle:
  *   ```
  *   val scope = CoroutineScope(SupervisorJob() + Dispatchers.IO)
  *   val datastore = createProtoDatastore(scope = scope, ...) { "/path/to/file" }
  *   // When done:
- *   scope.cancel()
+ *   datastore.close()
  *   ```
  * @param defaultJson The default [Json] instance to use for Kotlin Serialization-based fields in this proto datastore.
  * @param produceKotlinxIoPath A lambda that returns the file path as a [kotlinx.io.files.Path].
@@ -156,10 +167,11 @@ public fun <T> createProtoDatastore(
     key: String = "proto_datastore",
     corruptionHandler: ReplaceFileCorruptionHandler<T>? = null,
     migrations: List<DataMigration<T>> = emptyList(),
-    scope: CoroutineScope = CoroutineScope(Dispatchers.IO + SupervisorJob()),
+    scope: CoroutineScope? = null,
     defaultJson: Json = PreferenceDefaults.defaultJson,
     produceKotlinxIoPath: () -> KotlinxIoPath,
 ): GenericProtoDatastore<T> {
+    val datastoreScope = protoDatastoreScope(scope)
     val datastore = DataStoreFactory.create(
         storage = OkioStorage(
             fileSystem = systemFileSystem,
@@ -168,13 +180,14 @@ public fun <T> createProtoDatastore(
         ),
         corruptionHandler = corruptionHandler,
         migrations = migrations,
-        scope = scope,
+        scope = datastoreScope,
     )
     return GenericProtoDatastore(
         datastore = datastore,
         defaultValue = defaultValue,
         key = key,
         defaultJson = defaultJson,
+        ownedScope = datastoreScope,
     )
 }
 
@@ -191,15 +204,14 @@ public fun <T> createProtoDatastore(
  * @param key The key identifier for this proto datastore.
  * @param corruptionHandler An optional [ReplaceFileCorruptionHandler] to handle data corruption.
  * @param migrations A list of [DataMigration] to apply when the DataStore is created.
- * @param scope The [CoroutineScope] to use for DataStore operations. Defaults to an unmanaged
- *   `CoroutineScope(Dispatchers.IO + SupervisorJob())`, which is suitable for application-level
- *   singletons. To control the DataStore lifecycle (e.g., in a scoped component or for testing),
- *   pass a custom scope and cancel it when no longer needed:
+ * @param scope Optional parent [CoroutineScope] for DataStore operations. The returned
+ *   [GenericProtoDatastore] owns a child scope and cancels it from [GenericProtoDatastore.close].
+ *   Pass a custom scope to tie the datastore to a parent lifecycle:
  *   ```
  *   val scope = CoroutineScope(SupervisorJob() + Dispatchers.IO)
  *   val datastore = createProtoDatastore(scope = scope, ...) { "/path/to/file" }
  *   // When done:
- *   scope.cancel()
+ *   datastore.close()
  *   ```
  * @param defaultJson The default [Json] instance to use for Kotlin Serialization-based fields in this proto datastore.
  * @param producePath A lambda that returns the directory path as a [String].
@@ -212,10 +224,11 @@ public fun <T> createProtoDatastore(
     key: String = "proto_datastore",
     corruptionHandler: ReplaceFileCorruptionHandler<T>? = null,
     migrations: List<DataMigration<T>> = emptyList(),
-    scope: CoroutineScope = CoroutineScope(Dispatchers.IO + SupervisorJob()),
+    scope: CoroutineScope? = null,
     defaultJson: Json = PreferenceDefaults.defaultJson,
     producePath: () -> String,
 ): GenericProtoDatastore<T> {
+    val datastoreScope = protoDatastoreScope(scope)
     val datastore = DataStoreFactory.create(
         storage = OkioStorage(
             fileSystem = systemFileSystem,
@@ -224,12 +237,13 @@ public fun <T> createProtoDatastore(
         ),
         corruptionHandler = corruptionHandler,
         migrations = migrations,
-        scope = scope,
+        scope = datastoreScope,
     )
     return GenericProtoDatastore(
         datastore = datastore,
         defaultValue = defaultValue,
         key = key,
         defaultJson = defaultJson,
+        ownedScope = datastoreScope,
     )
 }

--- a/generic-datastore/src/commonMain/kotlin/io/github/arthurkun/generic/datastore/proto/CreateProtoDatastore.kt
+++ b/generic-datastore/src/commonMain/kotlin/io/github/arthurkun/generic/datastore/proto/CreateProtoDatastore.kt
@@ -8,25 +8,13 @@ import androidx.datastore.core.handlers.ReplaceFileCorruptionHandler
 import androidx.datastore.core.okio.OkioSerializer
 import androidx.datastore.core.okio.OkioStorage
 import io.github.arthurkun.generic.datastore.core.PreferenceDefaults
+import io.github.arthurkun.generic.datastore.core.createDatastoreScope
 import io.github.arthurkun.generic.datastore.core.systemFileSystem
 import kotlinx.coroutines.CoroutineScope
-import kotlinx.coroutines.Dispatchers
-import kotlinx.coroutines.IO
-import kotlinx.coroutines.Job
-import kotlinx.coroutines.SupervisorJob
 import kotlinx.serialization.json.Json
 import okio.Path.Companion.toPath
 import kotlin.jvm.JvmName
 import kotlinx.io.files.Path as KotlinxIoPath
-
-private fun protoDatastoreScope(parentScope: CoroutineScope?): CoroutineScope {
-    if (parentScope == null) {
-        return CoroutineScope(Dispatchers.IO + SupervisorJob())
-    }
-
-    val parentJob = parentScope.coroutineContext[Job]
-    return CoroutineScope(parentScope.coroutineContext + SupervisorJob(parentJob))
-}
 
 /**
  * Creates a [GenericProtoDatastore] using an [OkioSerializer] and a path producer
@@ -64,7 +52,7 @@ public fun <T> createProtoDatastore(
     defaultJson: Json = PreferenceDefaults.defaultJson,
     producePath: () -> String,
 ): GenericProtoDatastore<T> {
-    val datastoreScope = protoDatastoreScope(scope)
+    val datastoreScope = createDatastoreScope(scope)
     val datastore = DataStoreFactory.create(
         storage = OkioStorage(
             fileSystem = systemFileSystem,
@@ -117,7 +105,7 @@ public fun <T> createProtoDatastore(
     defaultJson: Json = PreferenceDefaults.defaultJson,
     produceOkioPath: () -> okio.Path,
 ): GenericProtoDatastore<T> {
-    val datastoreScope = protoDatastoreScope(scope)
+    val datastoreScope = createDatastoreScope(scope)
     val datastore = DataStoreFactory.create(
         storage = OkioStorage(
             fileSystem = systemFileSystem,
@@ -171,7 +159,7 @@ public fun <T> createProtoDatastore(
     defaultJson: Json = PreferenceDefaults.defaultJson,
     produceKotlinxIoPath: () -> KotlinxIoPath,
 ): GenericProtoDatastore<T> {
-    val datastoreScope = protoDatastoreScope(scope)
+    val datastoreScope = createDatastoreScope(scope)
     val datastore = DataStoreFactory.create(
         storage = OkioStorage(
             fileSystem = systemFileSystem,
@@ -228,7 +216,7 @@ public fun <T> createProtoDatastore(
     defaultJson: Json = PreferenceDefaults.defaultJson,
     producePath: () -> String,
 ): GenericProtoDatastore<T> {
-    val datastoreScope = protoDatastoreScope(scope)
+    val datastoreScope = createDatastoreScope(scope)
     val datastore = DataStoreFactory.create(
         storage = OkioStorage(
             fileSystem = systemFileSystem,

--- a/generic-datastore/src/commonMain/kotlin/io/github/arthurkun/generic/datastore/proto/GenericProtoDatastore.kt
+++ b/generic-datastore/src/commonMain/kotlin/io/github/arthurkun/generic/datastore/proto/GenericProtoDatastore.kt
@@ -19,6 +19,8 @@ import io.github.arthurkun.generic.datastore.proto.custom.optional.nullableSeria
 import io.github.arthurkun.generic.datastore.proto.custom.set.enumSetFieldInternal
 import io.github.arthurkun.generic.datastore.proto.custom.set.kserializedSetFieldInternal
 import io.github.arthurkun.generic.datastore.proto.custom.set.serializedSetFieldInternal
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.cancel
 import kotlinx.serialization.KSerializer
 import kotlinx.serialization.json.Json
 
@@ -30,12 +32,14 @@ import kotlinx.serialization.json.Json
  * @param T The proto message type.
  * @param datastore The underlying [DataStore<T>] instance.
  * @param defaultValue The default value for the proto message.
+ * @param ownedScope The scope owned by this wrapper when it creates the underlying [DataStore].
  */
 public class GenericProtoDatastore<T>(
     internal val datastore: DataStore<T>,
     private val defaultValue: T,
     private val key: String = "proto_datastore",
     private val defaultJson: Json = PreferenceDefaults.defaultJson,
+    private val ownedScope: CoroutineScope? = null,
 ) : ProtoDatastore<T> {
 
     private val cachedData: ProtoPreference<T> by lazy {
@@ -47,6 +51,10 @@ public class GenericProtoDatastore<T>(
     }
 
     override fun data(): ProtoPreference<T> = cachedData
+
+    override fun close() {
+        ownedScope?.cancel()
+    }
 
     override fun <F> field(
         defaultValue: F,

--- a/generic-datastore/src/commonMain/kotlin/io/github/arthurkun/generic/datastore/proto/ProtoDatastore.kt
+++ b/generic-datastore/src/commonMain/kotlin/io/github/arthurkun/generic/datastore/proto/ProtoDatastore.kt
@@ -12,17 +12,7 @@ import kotlinx.serialization.serializer
  *
  * @param T The proto message type.
  */
-public interface ProtoDatastore<T> {
-    /**
-     * Closes resources owned by this proto datastore wrapper.
-     *
-     * Datastores created with `createProtoDatastore` own the DataStore scope and cancel it here.
-     * Wrappers around an externally-created `DataStore<T>` may not own any resources, in which case
-     * this is a no-op.
-     */
-    public fun close() {
-    }
-
+public interface ProtoDatastore<T> : AutoCloseable {
     /**
      * Returns the proto message wrapped as a [DelegatedPreference] instance.
      *

--- a/generic-datastore/src/commonMain/kotlin/io/github/arthurkun/generic/datastore/proto/ProtoDatastore.kt
+++ b/generic-datastore/src/commonMain/kotlin/io/github/arthurkun/generic/datastore/proto/ProtoDatastore.kt
@@ -14,6 +14,16 @@ import kotlinx.serialization.serializer
  */
 public interface ProtoDatastore<T> {
     /**
+     * Closes resources owned by this proto datastore wrapper.
+     *
+     * Datastores created with `createProtoDatastore` own the DataStore scope and cancel it here.
+     * Wrappers around an externally-created `DataStore<T>` may not own any resources, in which case
+     * this is a no-op.
+     */
+    public fun close() {
+    }
+
+    /**
      * Returns the proto message wrapped as a [DelegatedPreference] instance.
      *
      * @return A [DelegatedPreference] instance for the proto message.

--- a/generic-datastore/src/commonMain/kotlin/io/github/arthurkun/generic/datastore/proto/ProtoDatastore.kt
+++ b/generic-datastore/src/commonMain/kotlin/io/github/arthurkun/generic/datastore/proto/ProtoDatastore.kt
@@ -13,6 +13,8 @@ import kotlinx.serialization.serializer
  * @param T The proto message type.
  */
 public interface ProtoDatastore<T> : AutoCloseable {
+    override fun close() {}
+
     /**
      * Returns the proto message wrapped as a [DelegatedPreference] instance.
      *

--- a/generic-datastore/src/commonTest/kotlin/io/github/arthurkun/generic/datastore/core/DatastoreScopeTest.kt
+++ b/generic-datastore/src/commonTest/kotlin/io/github/arthurkun/generic/datastore/core/DatastoreScopeTest.kt
@@ -1,0 +1,54 @@
+package io.github.arthurkun.generic.datastore.core
+
+import kotlinx.coroutines.Job
+import kotlinx.coroutines.cancel
+import kotlinx.coroutines.test.StandardTestDispatcher
+import kotlinx.coroutines.test.TestScope
+import kotlin.coroutines.ContinuationInterceptor
+import kotlin.test.Test
+import kotlin.test.assertFalse
+import kotlin.test.assertSame
+import kotlin.test.assertTrue
+
+class DatastoreScopeTest {
+
+    @Test
+    fun parentDispatcherIsPreserved() {
+        val dispatcher = StandardTestDispatcher()
+        val parentScope = TestScope(dispatcher)
+        val datastoreScope = createDatastoreScope(parentScope)
+
+        try {
+            assertSame(dispatcher, datastoreScope.coroutineContext[ContinuationInterceptor])
+        } finally {
+            datastoreScope.cancel()
+            parentScope.cancel()
+        }
+    }
+
+    @Test
+    fun parentCancellationCancelsDatastoreScope() {
+        val parentScope = TestScope()
+        val datastoreScope = createDatastoreScope(parentScope)
+        val datastoreJob = checkNotNull(datastoreScope.coroutineContext[Job])
+
+        parentScope.cancel()
+
+        assertFalse(datastoreJob.isActive)
+    }
+
+    @Test
+    fun datastoreScopeCancellationDoesNotCancelParent() {
+        val parentScope = TestScope()
+        val datastoreScope = createDatastoreScope(parentScope)
+        val parentJob = checkNotNull(parentScope.coroutineContext[Job])
+
+        try {
+            datastoreScope.cancel()
+
+            assertTrue(parentJob.isActive)
+        } finally {
+            parentScope.cancel()
+        }
+    }
+}

--- a/generic-datastore/src/jvmTest/kotlin/io/github/arthurkun/generic/datastore/DesktopPreferencesDatastoreLifecycleTest.kt
+++ b/generic-datastore/src/jvmTest/kotlin/io/github/arthurkun/generic/datastore/DesktopPreferencesDatastoreLifecycleTest.kt
@@ -1,0 +1,35 @@
+package io.github.arthurkun.generic.datastore
+
+import io.github.arthurkun.generic.datastore.preferences.createPreferencesDatastore
+import kotlinx.coroutines.test.runTest
+import org.junit.jupiter.api.io.TempDir
+import java.io.File
+import kotlin.test.Test
+import kotlin.test.assertEquals
+
+class DesktopPreferencesDatastoreLifecycleTest {
+
+    @TempDir
+    lateinit var tempFolder: File
+
+    @Test
+    fun closeAllowsDatastorePathToBeReopened() = runTest {
+        val path = "${tempFolder.absolutePath}/lifecycle.preferences_pb"
+        val firstDatastore = createPreferencesDatastore(
+            producePath = { path },
+        )
+
+        firstDatastore.string("name").set("first")
+        firstDatastore.close()
+
+        val secondDatastore = createPreferencesDatastore(
+            producePath = { path },
+        )
+
+        try {
+            assertEquals("first", secondDatastore.string("name").get())
+        } finally {
+            secondDatastore.close()
+        }
+    }
+}

--- a/generic-datastore/src/jvmTest/kotlin/io/github/arthurkun/generic/datastore/DesktopPreferencesDatastoreLifecycleTest.kt
+++ b/generic-datastore/src/jvmTest/kotlin/io/github/arthurkun/generic/datastore/DesktopPreferencesDatastoreLifecycleTest.kt
@@ -1,11 +1,16 @@
 package io.github.arthurkun.generic.datastore
 
 import io.github.arthurkun.generic.datastore.preferences.createPreferencesDatastore
+import kotlinx.coroutines.Job
+import kotlinx.coroutines.cancel
+import kotlinx.coroutines.test.StandardTestDispatcher
+import kotlinx.coroutines.test.TestScope
 import kotlinx.coroutines.test.runTest
 import org.junit.jupiter.api.io.TempDir
 import java.io.File
 import kotlin.test.Test
 import kotlin.test.assertEquals
+import kotlin.test.assertTrue
 
 class DesktopPreferencesDatastoreLifecycleTest {
 
@@ -30,6 +35,24 @@ class DesktopPreferencesDatastoreLifecycleTest {
             assertEquals("first", secondDatastore.string("name").get())
         } finally {
             secondDatastore.close()
+        }
+    }
+
+    @Test
+    fun closeDoesNotCancelParentScope() = runTest {
+        val parentScope = TestScope(StandardTestDispatcher(testScheduler))
+        val parentJob = checkNotNull(parentScope.coroutineContext[Job])
+        val datastore = createPreferencesDatastore(
+            scope = parentScope,
+            producePath = { "${tempFolder.absolutePath}/parent_scope.preferences_pb" },
+        )
+
+        try {
+            datastore.close()
+
+            assertTrue(parentJob.isActive)
+        } finally {
+            parentScope.cancel()
         }
     }
 }

--- a/generic-datastore/src/jvmTest/kotlin/io/github/arthurkun/generic/datastore/proto/core/DesktopProtoDatastoreLifecycleTest.kt
+++ b/generic-datastore/src/jvmTest/kotlin/io/github/arthurkun/generic/datastore/proto/core/DesktopProtoDatastoreLifecycleTest.kt
@@ -1,0 +1,39 @@
+package io.github.arthurkun.generic.datastore.proto.core
+
+import io.github.arthurkun.generic.datastore.proto.createProtoDatastore
+import kotlinx.coroutines.test.runTest
+import org.junit.jupiter.api.io.TempDir
+import java.io.File
+import kotlin.test.Test
+import kotlin.test.assertEquals
+
+class DesktopProtoDatastoreLifecycleTest {
+
+    @TempDir
+    lateinit var tempFolder: File
+
+    @Test
+    fun closeAllowsDatastorePathToBeReopened() = runTest {
+        val path = "${tempFolder.absolutePath}/lifecycle.pb"
+        val firstDatastore = createProtoDatastore(
+            serializer = TestProtoDataSerializer,
+            defaultValue = TestProtoData(),
+            producePath = { path },
+        )
+
+        firstDatastore.data().set(TestProtoData(id = 1, name = "first"))
+        firstDatastore.close()
+
+        val secondDatastore = createProtoDatastore(
+            serializer = TestProtoDataSerializer,
+            defaultValue = TestProtoData(),
+            producePath = { path },
+        )
+
+        try {
+            assertEquals("first", secondDatastore.data().get().name)
+        } finally {
+            secondDatastore.close()
+        }
+    }
+}

--- a/generic-datastore/src/jvmTest/kotlin/io/github/arthurkun/generic/datastore/proto/core/DesktopProtoDatastoreLifecycleTest.kt
+++ b/generic-datastore/src/jvmTest/kotlin/io/github/arthurkun/generic/datastore/proto/core/DesktopProtoDatastoreLifecycleTest.kt
@@ -1,11 +1,16 @@
 package io.github.arthurkun.generic.datastore.proto.core
 
 import io.github.arthurkun.generic.datastore.proto.createProtoDatastore
+import kotlinx.coroutines.Job
+import kotlinx.coroutines.cancel
+import kotlinx.coroutines.test.StandardTestDispatcher
+import kotlinx.coroutines.test.TestScope
 import kotlinx.coroutines.test.runTest
 import org.junit.jupiter.api.io.TempDir
 import java.io.File
 import kotlin.test.Test
 import kotlin.test.assertEquals
+import kotlin.test.assertTrue
 
 class DesktopProtoDatastoreLifecycleTest {
 
@@ -34,6 +39,26 @@ class DesktopProtoDatastoreLifecycleTest {
             assertEquals("first", secondDatastore.data().get().name)
         } finally {
             secondDatastore.close()
+        }
+    }
+
+    @Test
+    fun closeDoesNotCancelParentScope() = runTest {
+        val parentScope = TestScope(StandardTestDispatcher(testScheduler))
+        val parentJob = checkNotNull(parentScope.coroutineContext[Job])
+        val datastore = createProtoDatastore(
+            serializer = TestProtoDataSerializer,
+            defaultValue = TestProtoData(),
+            scope = parentScope,
+            producePath = { "${tempFolder.absolutePath}/parent_scope.pb" },
+        )
+
+        try {
+            datastore.close()
+
+            assertTrue(parentJob.isActive)
+        } finally {
+            parentScope.cancel()
         }
     }
 }


### PR DESCRIPTION
# New Pull Request
<!-- Thanks for sending a pull request! Make sure to follow the contributing guidelines. -->
<!-- Important note, we may remove your pull request if you do not use this provided PR template correctly. -->

## Pull Request Type

<!-- Please select what type of pull request this is: [x] -->
- [ ] Chore/Refactor
- [ ] Bugfix
- [X] Feature Implementation
- [ ] Documentation
- [ ] Other

## Related issue
<!-- Please link the issue your pull request is referring to. -->
<!-- If this pull request fully resolves the relevant issue, put "closes" before the issue number. -->
<!-- Example: "closes #123456". -->

## Description
<!-- Please write a clear and concise description of what the pull request does. -->
Enable to add option to control scope

## Screenshots <!-- If appropriate -->
<!-- Please add before and after screenshots if there is a visible change. -->

## Testing <!-- for code that is not small enough to be easily understandable -->
<!-- Has this pull request been tested? -->
<!-- Please describe shortly how you tested it. -->
<!-- Are there any ramifications remaining? -->

## Additional context
<!-- Add any other context about the pull request here. -->

This pull request introduces improved lifecycle management for `GenericPreferencesDatastore` by ensuring that each instance owns its own `CoroutineScope` for DataStore operations, which is properly cancelled when the datastore is closed. It also updates the API to allow users to optionally provide a parent scope, clarifies documentation, and adds a utility for consistent scope creation. These changes help prevent resource leaks and make lifecycle handling more explicit and robust.

**Lifecycle and CoroutineScope Management:**

* Added a new internal utility function `createDatastoreScope` in `DatastoreScope.kt` to consistently create a `CoroutineScope` for DataStore operations, using `Dispatchers.IO` and a `SupervisorJob`, optionally linked to a parent scope if provided.
* Updated all overloads of `createPreferencesDatastore` to accept an optional parent `CoroutineScope` (now nullable), and to use `createDatastoreScope` for creating a child scope that is owned by the returned `GenericPreferencesDatastore` instance. The owned scope is cancelled when `close()` is called, preventing leaks. [[1]](diffhunk://#diff-befa211bf3e625ea1334bf509680bba08f53a6e920ca15bb4e6a9e498c8b041bL35-R57) [[2]](diffhunk://#diff-befa211bf3e625ea1334bf509680bba08f53a6e920ca15bb4e6a9e498c8b041bL68-R71) [[3]](diffhunk://#diff-befa211bf3e625ea1334bf509680bba08f53a6e920ca15bb4e6a9e498c8b041bL78-R94) [[4]](diffhunk://#diff-befa211bf3e625ea1334bf509680bba08f53a6e920ca15bb4e6a9e498c8b041bL102-R108) [[5]](diffhunk://#diff-befa211bf3e625ea1334bf509680bba08f53a6e920ca15bb4e6a9e498c8b041bL112-R131) [[6]](diffhunk://#diff-befa211bf3e625ea1334bf509680bba08f53a6e920ca15bb4e6a9e498c8b041bL137-R146) [[7]](diffhunk://#diff-befa211bf3e625ea1334bf509680bba08f53a6e920ca15bb4e6a9e498c8b041bL147-R169)
* Updated imports and implementation in `GenericPreferencesDatastore.kt` to support scope cancellation on close.

**Documentation Updates:**

* Clarified the documentation for all `createPreferencesDatastore` overloads to describe the new scope ownership and lifecycle behavior, including how passing a parent scope ties the DataStore lifecycle to it. [[1]](diffhunk://#diff-befa211bf3e625ea1334bf509680bba08f53a6e920ca15bb4e6a9e498c8b041bL68-R71) [[2]](diffhunk://#diff-befa211bf3e625ea1334bf509680bba08f53a6e920ca15bb4e6a9e498c8b041bL78-R94) [[3]](diffhunk://#diff-befa211bf3e625ea1334bf509680bba08f53a6e920ca15bb4e6a9e498c8b041bL102-R108) [[4]](diffhunk://#diff-befa211bf3e625ea1334bf509680bba08f53a6e920ca15bb4e6a9e498c8b041bL112-R131) [[5]](diffhunk://#diff-befa211bf3e625ea1334bf509680bba08f53a6e920ca15bb4e6a9e498c8b041bL137-R146) [[6]](diffhunk://#diff-befa211bf3e625ea1334bf509680bba08f53a6e920ca15bb4e6a9e498c8b041bL147-R169)
* Updated the `README.md` to explain the new scope ownership model for both `createPreferencesDatastore` and `createProtoDatastore`, including the need to call `.close()` and the effect of passing a parent scope. [[1]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5R125-R128) [[2]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5R748-R751)

**Skill Documentation Addition:**

* Added a new skill guide at `.agents/skills/kotlin-flow-state-event-modeling/SKILL.md` that provides best practices for using Kotlin Flow, `StateFlow`, `SharedFlow`, and `Channel` for state and event modeling, with practical examples and anti-patterns.